### PR TITLE
add example configuration

### DIFF
--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -30,7 +30,7 @@ resources:
     # The resource schema URL.
     schema_url: http://schema.com
 
-# General attribute limits, applies to span and log attributes.
+# Limits
 limits:
   attributes:
     value_length: 0 # OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT
@@ -84,16 +84,6 @@ sdk:
           name: traceidratio
           args:
             ratio: 0.01
-    # The span limits.
-    span_limits:
-      # Merge general attribute limits with span specific limits.
-      attribute_count_limit: 20
-      attribute_value_length_limit: 200
-      # Span specific limits.
-      attribute_count_per_event_limit: 5
-      attribute_count_per_link_limit: 5
-      event_count_limit: 10
-      link_count_limit: 4
   # Meter provider configuration.
   meter_provider:
     resource: resource/resourceA # references identifier from resources section

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -1,0 +1,172 @@
+# This demonstrates a file configuration that falls out naturally from the SDK configuration options defined in the specification.
+# The configuration shown is a "kitchen sink" example, with all the available options shown for demonstration purposes.
+
+exporters:
+  otlp/exporterA:
+    protocols:
+      grpc:
+        endpoint: http://localost:4317
+        headers:
+          # TODO: Replace with environment variable when parsing to avoid storing secret in plain text
+          api-key: 1234
+        compression: gzip
+        timeout_millis: 30_000
+  logging:
+
+# The resource, can be used across providers
+resources:
+  resource/resourceA:
+    # List of enabled resource detectors. Each detector has a name (FQCN for java), and an optional list of excluded keys. Detector name supports wildcard syntax. Detectors are invoked and merged sequentially. Static attributes and schema_url comprise a resource which is merged last.
+    detectors:
+      - name: com.domain.resources.CustomResourceProvider
+      - name: io.opentelemetry.sdk.extension.resources.*
+        excluded_attribute_keys:
+          # Exclude process.command_line, which is often verbose and may contain secrets
+          - process.command_line
+    # List of static resource attribute key / value pairs.
+    attributes:
+      service.name: my-service
+      service.instance.id: 1234
+    # The resource schema URL.
+    schema_url: http://schema.com
+
+# General attribute limits, applies to span and log attributes.
+limits:
+  attributes:
+    value_length: 0 # OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT
+    count: 128      # OTEL_ATTRIBUTE_COUNT_LIMIT
+  spans:
+    attributes:
+      value_length: 0 # OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
+      count: 128      # OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT
+    event:
+      count: 128 # OTEL_SPAN_EVENT_COUNT_LIMIT
+      attributes:
+        count: 128 # OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT
+    link:
+      count: 128 # OTEL_SPAN_LINK_COUNT_LIMIT
+      attributes:
+         count: 128 # OTEL_LINK_ATTRIBUTE_COUNT_LIMIT
+
+# SDK configuration.
+sdk:
+  # Whether the SDK is enabled or not.
+  disabled: false
+  # Configure SDK logging.
+  logging:
+    level: info
+  # Tracer provider configuration.
+  tracer_provider:
+    resource: resource/resourceA # references identifier from resources section
+    # List of span processors, to be added sequentially. Each span processor has a name and args used to configure it.
+    span_processors:
+      # Add simple span processor configured to export with the logging exporter.
+      - name: simple
+        args:
+          # Simple span processor takes exporter as an arg
+          exporter: logging # references identifier from exporters section
+      # Add batch span processor configured to export with the OTLP exporter.
+      - name: batch
+        args:
+          # Batch span processor takes exporter as an arg
+          exporter: otlp/exporterA # references identifier from exporters section
+          # Configure batch span processor batch size and interval settings.
+          max_queue_size: 100
+          scheduled_delay_millis: 1_000
+          export_timeout_millis: 30_000
+          max_export_batch_size: 200
+    # The sampler. Each sampler has a name and args used to configure it.
+    sampler:
+      name: parentbased
+      args:
+        # The parentbased sampler takes root_sampler as an arg, is another sampler itself.
+        root_sampler:
+          name: traceidratio
+          args:
+            ratio: 0.01
+    # The span limits.
+    span_limits:
+      # Merge general attribute limits with span specific limits.
+      attribute_count_limit: 20
+      attribute_value_length_limit: 200
+      # Span specific limits.
+      attribute_count_per_event_limit: 5
+      attribute_count_per_link_limit: 5
+      event_count_limit: 10
+      link_count_limit: 4
+  # Meter provider configuration.
+  meter_provider:
+    resource: resource/resourceA # references identifier from resources section
+    # List of metric readers. Each metric reader has a name and args used to configure it.
+    metric_readers:
+      # Add periodic metric reader configured to export with the logging exporter using the default interval settings.
+      - name: periodic
+        args:
+          # Periodic metric reader takes exporter as an arg
+          exporter: logging # references identifier from exporters section
+      # Add periodic metric reader configured to export with the otlp exporter every 5_000 ms.
+      - name: periodic
+        args:
+          # Periodic metric reader takes exporter as an arg, which is composed of a name an args used to configure it.
+          exporter: otlp/exporterA # references identifier from exporters section
+          # Configure periodic metric reader interval.
+          interval_millis: 5_000
+    # List of views. Each view consists of a selector defining criteria for which instruments are selected, and a view defining the resulting metric.
+    views:
+      # Add a "kitchen sink" view, using all selector fields, and using all configurable aspects of the view.
+      - selector:
+          # Select instruments with this name, including wildcard matching.
+          instrument_name: my-instrument
+          # Select instruments with this type.
+          instrument_type: COUNTER
+          # Select instruments with this meter name.
+          meter_name: my-meter
+          # Select instruments with this meter version.
+          meter_version: 1.0.0
+          # Select instruments with this meter schema url.
+          meter_schema_url: http://example.com
+        view:
+          # Change the metric name.
+          name: new-instrument-name
+          # Change the metric description.
+          description: new-description
+          # Change the aggregation. In this case, use an explicit bucket histogram with bucket boundaries [1.0, 2.0, 5.0].
+          aggregation:
+            name: explicit_bucket_histogram
+            args:
+              bucket_boundaries: [1.0, 2.0, 5.0]
+          # List of attribute keys to retain. Keys included on measurements and not in this list will be ignored.
+          attribute_keys:
+            - foo
+            - bar
+      # Add a simpler view, which configures the drop aggregation for instruments whose name matches "*.server.duration".
+      - selector:
+          instrument_name: "*.server.duration"
+        view:
+          aggregation:
+            name: drop
+  # Logger provider configuration.
+  logger_provider:
+    resource: resource/resourceA # references identifier from resources section
+    # List of log processors, to be added sequentially. Each log processor has a name and args used to configure it.
+    log_record_processors:
+      # Add batch log processor configured to export with the OTLP exporter.
+      - name: batch
+        args:
+          # Batch log processor takes exporter as an arg
+          exporter: otlp/exporterA # references identifier from exporters section
+          # Configure batch log processor batch size and interval settings.
+          max_queue_size: 50
+          scheduled_delay_millis: 1_000
+          export_timeout_millis: 30_000
+          max_export_batch_size: 200
+  # List of context propagators. Each propagator has a name and args used to configure it. None of the propagators here have configurable options so args are not demonstrated.
+  propagators:
+    - name: tracecontext
+    - name: baggage
+# Undefined placeholder for instrumentation specific configuration. Need to define how instrumentation is configured in a language agnostic way.
+instrumentation:
+# language specific options
+python:
+java:
+...

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -154,9 +154,59 @@ sdk:
   propagators:
     - name: tracecontext
     - name: baggage
-# Undefined placeholder for instrumentation specific configuration. Need to define how instrumentation is configured in a language agnostic way.
+# Using examples provided in https://github.com/MrAlias/otel-schema/issues/8
 instrumentation:
+  java:
+    http:
+      capture_headers:
+        client:
+          request: # otel.instrumentation.http.capture-headers.client.request
+            enabled: true
+            headers:
+              - "User-Agent"
+          response: # otel.instrumentation.http.capture-headers.client.response
+            enabled: false
+        server:
+          request: # otel.instrumentation.http.capture-headers.server.request
+            enabled: false
+          response: # otel.instrumentation.http.capture-headers.server.response
+            enabled: true
+            headers:
+              - "Content-Type"
+  python:
+    falcon:
+      enabled: false # OTEL_PYTHON_DISABLED_INSTRUMENTATIONS
+      excluded_urls: # OTEL_PYTHON_FALCON_EXCLUDED_URLS
+        - http://falcon.com/healthcheck
+    fastapi:
+      excluded_urls: # OTEL_PYTHON_FASTAPI_EXCLUDED_URLS
+        - http://fastapi.com/healthcheck
+    django:
+      request_attributes: # OTEL_PYTHON_DJANGO_TRACED_REQUEST_ATTRS
+        - "content_type"
+        - "path_info"
 # language specific options
 python:
+  context: "contextvars" # OTEL_PYTHON_CONTEXT
+  id_generator:
+    name: "random" # OTEL_PYTHON_ID_GENERATOR
+    # possibly an id generator could require arguments
+  
+  # what would setting these mean for SDK
+  # configuration? would it be parsed by an alternate
+  # SDK?
+  tracer_provider: # OTEL_PYTHON_TRACER_PROVIDER
+  meter_provider: # OTEL_PYTHON_METER_PROVIDER
+  logger_provider: # OTEL_PYTHON_LOGGER_PROVIDER
+
+  logging_auto_instrumentation_enabled: false # OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED
+  
+  excluded_url: # OTEL_PYTHON_EXCLUDED_URLS
+    - http://excludeddomain.com/healthcheck
 java:
+  resource_providers: # otel.java.enabled.resource-providers
+    enabled:
+      - providerA
+    disabled:
+      - providerB
 ...


### PR DESCRIPTION
The propose configuration is a combination of the proposal in the description of #5 and of the kitchen-sink yaml. I've pulled limits, exporters, and resources out of the `sdk` block. I kept the rest of the configuration mostly intact.

Fix #5