### PR TITLE
Downgrade configuration model requirement from MUST to MAY

### DIFF
--- a/OTEP.md
+++ b/OTEP.md
@@ -103,10 +103,10 @@ Implementations *MUST* allow users to specify an environment variable to set the
 
 ### Configuration model
 
-To allow SDKs and instrumentation libraries to parse configuration without having to implement the parsing logic, a `Configuration` model *MUST* be provided by implementations. This object:
+To allow SDKs and instrumentation libraries to accept configuration without having to implement the parsing logic, a `Configuration` model *MAY* be provided by implementations. This object:
 
 * has already been parsed from a file or data structure
-* has been validated
+* is structurally valid (errors may yet occur when SDK or instrumentation interprets the object)
 
 ### Additional interface: ParseAndValidateConfiguration
 


### PR DESCRIPTION
As mentioned in CNCF slack, I think MUST is too strong a requirement here without a better understanding of how instrumentation would be expected to access / adhere to configuration. I.e can we force native instrumentation to adhere to file based configuration options?

Some language SIGs may view it useful to provide a model which can be used in code to programmatically define configuration, but others will view it as frivolous duplication of the SDK APIs which already exist.

Let's lighten the "MUST" requirement to "MAY".